### PR TITLE
Fixing #1 by help of @Thura98's comment

### DIFF
--- a/build-alpine
+++ b/build-alpine
@@ -78,6 +78,10 @@ get_static_apk () {
 
     if [ "$auto_repo_dir" ]; then
         mirror_list=$rootfs/usr/share/alpine-mirrors/MIRRORS.txt
+
+        mkdir -p $rootfs/usr/share/alpine-mirrors/
+        wget http://alpine.mirror.wearetriple.com/MIRRORS.txt -O $rootfs/usr/share/alpine-mirrors/MIRRORS.txt
+
         mirror_count=$(wc -l $mirror_list | cut -d " " -f 1)
         random=$(hexdump -n 2 -e '/2 "%u"' /dev/urandom)
         repository=$(sed $(expr $random % $mirror_count + 1)\!d \


### PR DESCRIPTION
There's an error while building the script: 

Error states: 
```matlab
wc: /home/umar_0x01/alpine/rootfs/usr/share/alpine-mirrors/MIRRORS.txt: No such file or directory
sed: -e expression #1, char 2: invalid usage of line address 0
Selecting mirror /v3.13/main
WARNING: Ignoring /v3.13/main: No such file or directory
ERROR: unable to select packages:
  alpine-base (no such package):
    required by: world[alpine-base]
Failed to install rootfs

```

![image](https://user-images.githubusercontent.com/18597330/115522061-36586b80-a2a5-11eb-8c95-38f251d13cf9.png)

---

Fixation: 
Create the `alpine-mirrors` directory inside `share/` and download `MIRRORS.txt` file in it. 

Automation (with help of https://github.com/saghul/lxd-alpine-builder/issues/1#issuecomment-770207874): 
```sh
mkdir -p $rootfs/usr/share/alpine-mirrors/
wget http://alpine.mirror.wearetriple.com/MIRRORS.txt -O $rootfs/usr/share/alpine-mirrors/MIRRORS.txt
```

Building with fixes: 
![image](https://user-images.githubusercontent.com/18597330/115522455-8cc5aa00-a2a5-11eb-99cc-894ae8b192ea.png)

![image](https://user-images.githubusercontent.com/18597330/115522500-964f1200-a2a5-11eb-8d02-2c41d102f944.png)

