### PR TITLE
Added sha256sum for alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub

### DIFF
--- a/build-alpine
+++ b/build-alpine
@@ -9,7 +9,8 @@ key_sha256sums="9c102bcc376af1498d549b77bdbfa815ae86faa1d2d82f040e616b18ef2df2d4
 2adcf7ce224f476330b5360ca5edb92fd0bf91c92d83292ed028d7c4e26333ab  alpine-devel@lists.alpinelinux.org-4d07755e.rsa.pub
 ebf31683b56410ecc4c00acd9f6e2839e237a3b62b5ae7ef686705c7ba0396a9  alpine-devel@lists.alpinelinux.org-5243ef4b.rsa.pub
 1bb2a846c0ea4ca9d0e7862f970863857fc33c32f5506098c636a62a726a847b  alpine-devel@lists.alpinelinux.org-524d27bb.rsa.pub
-12f899e55a7691225603d6fb3324940fc51cd7f133e7ead788663c2b7eecb00c  alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub"
+12f899e55a7691225603d6fb3324940fc51cd7f133e7ead788663c2b7eecb00c  alpine-devel@lists.alpinelinux.org-5261cecb.rsa.pub
+207e4696d3c05f7cb05966aee557307151f1f00217af4143c1bcaf33b8df733f  alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub"
 
 
 get_static_apk () {


### PR DESCRIPTION
This change should solve the error:
```
...
ERROR: checksum is missing for alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub
Failed to download a valid static apk
...
```